### PR TITLE
Return Err(String) rather than panic

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -31,7 +31,6 @@ pub fn eval(tokens: &[RPNToken]) -> i32 {
             }
             RPNToken::Operator(Operator::LPAREN) => panic!("Stray ( in eval"),
             RPNToken::Operator(Operator::RPAREN) => panic!("Stray ) in eval"),
-            RPNToken::Operator(Operator::INVALID(c)) => panic!("Invalid operator: {}", c),
             RPNToken::Operand(v) => stack.push(v),
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -13,7 +13,6 @@ pub enum Operator {
     POW,
     LPAREN,
     RPAREN,
-    INVALID(char),
 }
 
 impl Operator {
@@ -26,14 +25,12 @@ impl Operator {
             Operator::POW => 3,
             Operator::LPAREN => 0,
             Operator::RPAREN => 0,
-            Operator::INVALID(_) => 0,
         }
     }
-}
 
-impl From<char> for Operator {
-    fn from(c: char) -> Self {
-        match c {
+    // Until std::convert::TryFrom stabilizes
+    pub fn try_from_char(c: char) -> Option<Operator> {
+        Some(match c {
             '+' => Operator::PLUS,
             '-' => Operator::MINUS,
             '*' => Operator::MULTIPLY,
@@ -41,7 +38,7 @@ impl From<char> for Operator {
             '^' => Operator::POW,
             '(' => Operator::LPAREN,
             ')' => Operator::RPAREN,
-            c => Operator::INVALID(c),
-        }
+            _ => return None,
+        })
     }
 }

--- a/tests/test_shunting_yard.rs
+++ b/tests/test_shunting_yard.rs
@@ -92,3 +92,10 @@ fn test_deep_stack() {
     let tokens = parse::parse(equa).unwrap();
     assert_eq!(eval::eval(&tokens), 1 - 2 + 3 * 4 * 5 + 6 - 7 + 8 - 9);
 }
+
+#[test]
+fn test_error() {
+    let equa = "9999999999999999999999 + 235";
+    let tokens = parse::parse(equa);
+    assert!(tokens.is_err());
+}


### PR DESCRIPTION
This also removes Operator::Invalid in favor of returning an error rather than an invalid-operator carrying expression